### PR TITLE
Move hardcoded ngroc link to central urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npm run dev  # Runs on http://localhost:5173/
 
 > Tip:
 > To see live data locally, temporarily set CURRENT_WS_URL in
-> websocketUrls.js to LOCAL. Don’t forget to switch it back to NGROK before publishing.
+> endpointUrls.js to LOCAL. Don’t forget to switch it back to NGROK before publishing.
 
 # Publishing the Webpage
 **Deploy with Vercel**
@@ -99,7 +99,7 @@ tmux new -s ngrok_ws
 ngrok http 8765
 ```
 
-Copy the new ngrok URL and update websocketUrls.js:
+Copy the new ngrok URL and update endpointUrls.js:
 
 ```javascript
 NGROK: 'wss://<your_ngrok_subdomain>.ngrok-free.app'

--- a/data/api_mech1.py
+++ b/data/api_mech1.py
@@ -1,10 +1,11 @@
+
 """
 FastAPI Backend for Mechanism 1 Dashboard
 Serves strategy data from InfluxDB as a clean JSON API
 """
 
 import os
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd
 from influxdb_client import InfluxDBClient
@@ -12,6 +13,7 @@ from dotenv import load_dotenv
 import requests
 from typing import Optional
 import uvicorn
+import time
 
 # ------------------------------
 # Load ENV Variables
@@ -39,6 +41,20 @@ query_api = client.query_api()
 # FastAPI App
 # ------------------------------
 app = FastAPI(title="Mechanism 1 API", version="1.0.0")
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    start = time.time()
+    response = await call_next(request)
+    ms = (time.time() - start) * 1000
+
+    print(
+        f"[REQ] {request.client.host} "
+        f"{request.method} {request.url.path} "
+        f"status={response.status_code} "
+        f"{ms:.1f}ms"
+    )
+    return response
 
 # CORS for React frontend
 app.add_middleware(
@@ -324,8 +340,16 @@ def safe_str(val):
 
 @app.get("/api/mech1/strategies")
 async def get_strategies(block: Optional[int] = None):
+    print(f"[STRATEGIES] requested block={block}")
+
     """Get all strategies for a given block (or latest if not specified)"""
     _, filtered_df, metadata, current_block, all_blocks = load_mechanism1_metrics(block)
+
+    print(
+        f"[STRATEGIES] using block={current_block} "
+        f"miners={len(filtered_df)} "
+        f"metadata={metadata}"
+    )
     
     # Load miner strategies
     miner_strategies = []

--- a/src/components/MinerGraph.jsx
+++ b/src/components/MinerGraph.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import websocketConfig from '../config/websocketUrls'; 
+import endpointConfig from '../config/endpointUrls'; 
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +29,7 @@ export default function MinerGraphV1() {
   const chartRef = useRef(null);
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
 
     wsRef.current = ws;
 

--- a/src/components/PerformanceGraphLR.jsx
+++ b/src/components/PerformanceGraphLR.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import websocketConfig from '../config/websocketUrls';
+import endpointConfig from '../config/endpointUrls';
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +29,7 @@ export default function InvestorGraphLR() {
   const [runId, setRunId] = useState(null);
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/src/components/PerformanceGraphLoss.jsx
+++ b/src/components/PerformanceGraphLoss.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
-import websocketConfig from "../config/websocketUrls";
+import endpointConfig from "../config/endpointUrls";
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +29,7 @@ export default function InvestorGraphLoss() {
   const [runId, setRunId] = useState(null);
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/src/components/PerformanceGraphPeers.jsx
+++ b/src/components/PerformanceGraphPeers.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import websocketConfig from '../config/websocketUrls';
+import endpointConfig from '../config/endpointUrls';
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +29,7 @@ export default function InvestorGraphPeers() {
   const [runId, setRunId] = useState(null);
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/src/components/PerformanceGraphPerplexity.jsx
+++ b/src/components/PerformanceGraphPerplexity.jsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
-import websocketConfig from "../config/websocketUrls";
+import endpointConfig from "../config/endpointUrls";
 
 ChartJS.register(
   CategoryScale,
@@ -31,7 +31,7 @@ export default function InvestorGraphPerplexity() {
   const [runId, setRunId] = useState(null);
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/src/config/endpointUrls.js
+++ b/src/config/endpointUrls.js
@@ -1,4 +1,4 @@
-// src/config/websocketUrls.js
+// src/config/endpointUrls.js
 
 const WS_ENV = {
   LOCAL: 'ws://localhost:8765',
@@ -9,6 +9,7 @@ const WS_ENV = {
 const API_ENV = {
   MECH1_LOCAL: 'http://localhost:22557',
   MECH1_PROD: import.meta.env.VITE_MECH1_API_URL || 'http://localhost:22557',
+  MECH1_PROD_NGROK: 'https://ngrok-dash1.dstrbtd.ai',
 };
 
 const CURRENT_WS_URL = WS_ENV.NGROK;
@@ -17,5 +18,5 @@ export default {
   WS_URL: CURRENT_WS_URL,
   WS_ENV,
   API_ENV,
-  MECH1_API_URL: API_ENV.MECH1_PROD,
+  MECH1_API_URL: API_ENV.MECH1_PROD_NGROK,
 };

--- a/src/pages/BenchmarksMech1Dash.jsx
+++ b/src/pages/BenchmarksMech1Dash.jsx
@@ -3,12 +3,12 @@ import { HiOutlineFlag, HiOutlineTrendingDown, HiOutlineWifi, HiOutlineLightning
 import { RiBarChartLine } from 'react-icons/ri';
 import StrategyCard from '../components/StrategyCard';
 import '../styles/Mech1Dashboard.css';
+import endpointConfig from '../config/endpointUrls'; 
 
 // Toggle to show/hide the right metrics panel
 const SHOW_METRICS_PANEL = false;
 
-// API endpoint
-const API_BASE_URL = import.meta.env.VITE_MECH1_API_URL || 'https://ngrok-dash1.dstrbtd.ai';
+const API_BASE_URL = endpointConfig.MECH1_API_URL
 
 const BenchmarksMech1Dashboard = () => {
   const [strategies, setStrategies] = useState([]);

--- a/src/pages/PerformanceDash.jsx
+++ b/src/pages/PerformanceDash.jsx
@@ -3,7 +3,7 @@ import InvestorGraphLoss from '../components/PerformanceGraphLoss';
 import InvestorGraphPerplexity from '../components/PerformanceGraphPerplexity';
 import InvestorGraphPeers from '../components/PerformanceGraphPeers';
 import InvestorGraphLR from '../components/PerformanceGraphLR';
-import websocketConfig from '../config/websocketUrls';
+import endpointConfig from '../config/endpointUrls';
 import '../styles/PerformanceDashboard.css';
 
 const PerformanceDashboard = () => {
@@ -13,7 +13,7 @@ const PerformanceDashboard = () => {
   const [modelName, setModelName] = useState("distributed/llama-4b");
 
   useEffect(() => {
-    const ws = new WebSocket(websocketConfig.WS_URL);
+    const ws = new WebSocket(endpointConfig.WS_URL);
 
     ws.onmessage = (event) => {
       try {


### PR DESCRIPTION
This PR does 2 things:
- It renames `websocketUrls.js` to `endpointUrls.js`
- It moves hardcoded api url logic in `BenchmarksMech1Dash.jsx  ` to `endpointUrls.js` to centrally organize.